### PR TITLE
Fixed Chrome bug in this-chart.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Customizing the Look
 
 - In the live_files/img directory, replace "header_logo_black.png" with whatever you want to appear in the upper left of the bingo card. (Or you can delete it altogether and remove the line referencing it from printcard.html and embed.html.)
 
+- In live_files/js/this-chart.js, on line 147, change the "hashtags=debatebingo" parameter in the URL to "hashtags=emmysbingo" or whatever hashtag you want to use for the event. In the live_files/embed.html on line 156, update the hashtag #debatebingo to your new hashtag for this card. 
+
 Setting Up the Tiles
 --------------------
 

--- a/live_files/js/this-chart.js
+++ b/live_files/js/this-chart.js
@@ -114,7 +114,7 @@ function add_chip(row, col)
     {
         $card.css('background-image', 'url("img/piece_chip.png")');
     }
-    $cardtext.hide();
+    //$cardtext.hide();
 
 }
 function remove_chip(row, col)
@@ -303,7 +303,7 @@ function make_card()
             else {
                 $(this).css('background-image', 'url("img/piece_chip.png")');
             }
-            $('#' + cardid + ' .card-text').hide();
+            //$('#' + cardid + ' .card-text').hide();
         }
         else if($(this).hasClass('free'))
         {


### PR DESCRIPTION
Commented out lines 117 and 306 to fix a Chrome version 29.0.1547.65 display issue. The bingo piece would not show up when you clicked on a square and the entire square would disappear.
As a result, if you clicked on any square on the right column, the first square on the left in the row below would jump up, staggering the display.

![screen shot 2013-09-12 at 11 32 06 am](https://f.cloud.github.com/assets/713778/1131832/83b01fd2-1bc0-11e3-8f56-a1fa1dc46557.png)
Now, the text will remain and the piece will appear beneath the text.
